### PR TITLE
Removed dependency of DiscordClient needing to be public in the Role Menu System

### DIFF
--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -23,7 +23,7 @@ namespace DevExchangeBot
         // TODO: The client class shouldn't be public, but there are
         // compatibility issues with the role menu system if we make
         // this private. This needs fixing.
-        public static DiscordClient Client { get; private set; }
+        private static DiscordClient Client { get; set; }
         public static ConfigModel Config { get; private set; }
 
         private static void Main()

--- a/src/Storage/Models/RoleMenuModel.cs
+++ b/src/Storage/Models/RoleMenuModel.cs
@@ -1,3 +1,4 @@
+using DSharpPlus;
 using DSharpPlus.Entities;
 using System;
 using System.Collections.Generic;
@@ -33,7 +34,7 @@ namespace DevExchangeBot.Storage.Models
             Roles = new List<RoleBind>();
         }
 
-        public DiscordEmoji[] GetAllEmojis()
+        public DiscordEmoji[] GetAllEmojis(DiscordClient client)
         {
             var emojis = new DiscordEmoji[Roles.Count];
 
@@ -41,7 +42,7 @@ namespace DevExchangeBot.Storage.Models
             for (int i = 0; i < emojis.Length; i++)
             {
                 if (Roles[i].EmojiId == 0) emojis[i] = DiscordEmoji.FromUnicode(Roles[i].EmojiUnicode);
-                else emojis[i] = DiscordEmoji.FromGuildEmote(Program.Client, Roles[i].EmojiId);
+                else emojis[i] = DiscordEmoji.FromGuildEmote(client, Roles[i].EmojiId);
             }
 
             return emojis;


### PR DESCRIPTION
Methods now require you to pass the DiscordClient variable through their parameters. Eliminates the need to keep Program.Client public