### PR TITLE
Small tweak to prevent users from spamming

### DIFF
--- a/src/ClientEvents.cs
+++ b/src/ClientEvents.cs
@@ -25,9 +25,11 @@ namespace DevExchangeBot
                 StorageContext.Model.AddUser(user);
             }
 
+            if (user.LastMessageTime + TimeSpan.FromMinutes(1) > e.Message.CreationTimestamp.DateTime) return;
+
             var content = e.Message.Content;
 
-            Regex.Replace(content, ":[0-9a-z]+:", "0", RegexOptions.IgnoreCase);
+            Regex.Replace(content, "<:[a-zA-Z]+:[0-9]+>", "0", RegexOptions.IgnoreCase);
             user.Exp += (int)Math.Round(content.Length / 2D * StorageContext.Model.ExpMultiplier, MidpointRounding.ToZero);
 
             if (user.Exp > user.ExpToNextLevel)
@@ -37,6 +39,8 @@ namespace DevExchangeBot
 
                 await e.Channel.SendMessageAsync($"{Program.Config.Emoji.Confetti} {e.Author.Mention} advanced to level {user.Level}!");
             }
+
+            user.LastMessageTime = e.Message.CreationTimestamp.DateTime;
         }
 
         public static async Task OnMessageCreatedAutoQuoter(DiscordClient sender, MessageCreateEventArgs e)

--- a/src/Storage/Models/UserModel.cs
+++ b/src/Storage/Models/UserModel.cs
@@ -1,4 +1,6 @@
 ﻿
+using System;
+
 namespace DevExchangeBot.Storage.Models
 {
     public class UserModel
@@ -13,5 +15,7 @@ namespace DevExchangeBot.Storage.Models
         public int Level { get; set; }
 
         public int ExpToNextLevel => Level * 100 + 75;
+
+        public DateTime LastMessageTime { get; set; }
     }
 }


### PR DESCRIPTION
I upgraded levelling, by adding a one-minute delay between registered messages to prevent spam. EXP formula is unchanged.