### PR TITLE
Patch: Levelling channel

### DIFF
--- a/src/ClientEvents.cs
+++ b/src/ClientEvents.cs
@@ -37,7 +37,29 @@ namespace DevExchangeBot
                 user.Exp -= user.ExpToNextLevel;
                 user.Level += 1;
 
-                await e.Channel.SendMessageAsync($"{Program.Config.Emoji.Confetti} {e.Author.Mention} advanced to level {user.Level}!");
+                if (StorageContext.Model.LevelUpChannelId == 0 || StorageContext.Model.EnableLevelUpChannel == false)
+                    await e.Channel.SendMessageAsync($"{Program.Config.Emoji.Confetti} {e.Author.Mention} advanced to level {user.Level}!");
+                else
+                {
+                    DiscordChannel channel;
+
+                    try
+                    {
+                        channel = e.Guild.GetChannel(StorageContext.Model.LevelUpChannelId);
+                    }
+                    catch (Exception exception)
+                    {
+                        sender.Logger.LogWarning(exception, "Could not get level-up channel of ID '{ChannelID}'",
+                            StorageContext.Model.LevelUpChannelId);
+                        await e.Channel.SendMessageAsync(
+                            $"{Program.Config.Emoji.Confetti} {e.Author.Mention} advanced to level {user.Level}!");
+
+                        user.LastMessageTime = e.Message.CreationTimestamp.DateTime;
+                        return;
+                    }
+
+                    await channel.SendMessageAsync($"{Program.Config.Emoji.Confetti} {e.Author.Mention} advanced to level {user.Level}!");
+                }
             }
 
             user.LastMessageTime = e.Message.CreationTimestamp.DateTime;

--- a/src/ClientEvents.cs
+++ b/src/ClientEvents.cs
@@ -32,7 +32,7 @@ namespace DevExchangeBot
             Regex.Replace(content, "<:[a-zA-Z]+:[0-9]+>", "0", RegexOptions.IgnoreCase);
             user.Exp += (int)Math.Round(content.Length / 2D * StorageContext.Model.ExpMultiplier, MidpointRounding.ToZero);
 
-            if (user.Exp > user.ExpToNextLevel)
+            while (user.Exp > user.ExpToNextLevel)
             {
                 user.Exp -= user.ExpToNextLevel;
                 user.Level += 1;

--- a/src/Commands/LevellingCommands.cs
+++ b/src/Commands/LevellingCommands.cs
@@ -170,5 +170,31 @@ namespace DevExchangeBot.Commands
                     .AddEmbed(builder)
                     .AsEphemeral(true));
         }
+
+        [SlashCommand("setlevelupchannel", "Sets the channel where level-up messages should be displayed.")]
+        public async Task SetLevelUpChannel(InteractionContext ctx,
+            [Option("Channel", "Channel to display the level-up messages in")]
+            DiscordChannel channel,
+            [Option("Enable",
+                "If false, will send the level-up message in the current channel. Defaults to true.")]
+            bool enable = true)
+        {
+            if (channel.Type != ChannelType.Text)
+            {
+                await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource,
+                    new DiscordInteractionResponseBuilder()
+                        .WithContent($"{Program.Config.Emoji.Failure} You can only use a text channel!")
+                        .AsEphemeral(true));
+                return;
+            }
+
+            StorageContext.Model.LevelUpChannelId = channel.Id;
+            StorageContext.Model.EnableLevelUpChannel = enable;
+
+            await ctx.CreateResponseAsync(InteractionResponseType.ChannelMessageWithSource,
+                new DiscordInteractionResponseBuilder()
+                    .WithContent($"{Program.Config.Emoji.Success} Settings successfully updated!")
+                    .AsEphemeral(true));
+        }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -82,8 +82,7 @@ namespace DevExchangeBot
 
             if (Config.GuildId != 0)
             {
-                slash.RegisterCommands<LevellingCommands>(Config
-                    .GuildId); //TODO: Precise your own guildID in config.json!
+                slash.RegisterCommands<LevellingCommands>(Config.GuildId); // TODO: Precise your own guildID in config.json!
                 slash.RegisterCommands<HeartboardCommands>(Config.GuildId);
                 slash.RegisterCommands<QuoterCommands>(Config.GuildId);
                 slash.RegisterCommands<RoleMenuCommands>(Config.GuildId);

--- a/src/Storage/StorageModel.cs
+++ b/src/Storage/StorageModel.cs
@@ -7,6 +7,8 @@ namespace DevExchangeBot.Storage
     {
         public Dictionary<ulong, UserModel> Users { get; set; }
         public float ExpMultiplier { get; set; }
+        public bool EnableLevelUpChannel { get; set; }
+        public ulong LevelUpChannelId { get; set; }
 
         public ulong HeartBoardChannel { get; set; }
         public bool HeartBoardEnabled { get; set; }


### PR DESCRIPTION
Added stuff to be able to set a channel to use for level-up messages.
Also fixed a bug that prevented level-ups in a row.