### PR TITLE
Upgrade: Publishing

### DIFF
--- a/DevExchangeBot.csproj
+++ b/DevExchangeBot.csproj
@@ -5,6 +5,11 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="DSharpPlus" Version="4.1.0-nightly-00930" />
     <PackageReference Include="DSharpPlus.CommandsNext" Version="4.1.0-nightly-00930" />
@@ -18,9 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="config.json">
+    <EmbeddedResource Include="config.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/src/Configuration/ConfigModel.cs
+++ b/src/Configuration/ConfigModel.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
 
 namespace DevExchangeBot.Configuration
 {
@@ -19,5 +22,12 @@ namespace DevExchangeBot.Configuration
         public int HeartboardRequirement { get; set; }
 
         public RoleMenuConfigModel RoleMenu { get; set; }
+
+        public static string GetEmbedConfiguration()
+        {
+            using var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("DevExchangeBot.config.json");
+            using var streamReader = new StreamReader(stream ?? throw new InvalidOperationException("Embed configuration could not be found!"));
+            return streamReader.ReadToEnd();
+        }
     }
 }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -16,6 +16,7 @@ using DSharpPlus.SlashCommands.Attributes;
 using DSharpPlus.SlashCommands.EventArgs;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
+using Serilog;
 
 namespace DevExchangeBot
 {
@@ -26,12 +27,10 @@ namespace DevExchangeBot
 
         private static void Main()
         {
-            // Ensure the config.json file is copied to the output directory.
-            if (!File.Exists("config.json"))
-                throw new FileNotFoundException("Configuration file could not be found.", "config.json");
+            // Assign the config to either the config.json file or the embedded version
+            Config = JsonConvert.DeserializeObject<ConfigModel>(File.Exists("config.json")
+                ? File.ReadAllText("config.json") : ConfigModel.GetEmbedConfiguration());
 
-            // Parse the content of the configuration file and fire up the MainAsync method.
-            Config = JsonConvert.DeserializeObject<ConfigModel>(File.ReadAllText("config.json"));
             MainAsync().GetAwaiter().GetResult();
         }
 
@@ -45,6 +44,10 @@ namespace DevExchangeBot
                 Intents = DiscordIntents.All,
                 LoggerFactory = Logging.SetUpAndGetLoggerFactory()
             });
+
+            // Warn if we're using the embedded configuration
+            if (!File.Exists("config.json"))
+                Log.Warning("Configuration file not found, using embedded configuration!");
 
             // Register all of the events
             Client.MessageCreated += ClientEvents.OnMessageCreatedLevelling;


### PR DESCRIPTION
I made the config file embedded to allow for clean single-file publishing; If you wish to publish the project, you can use the following commands.
`dotnet publish DevExchangeBot.sln --framework net5.0 --configuration Release --runtime linux-x64 -p:PublishSingleFile=true --self-contained false`
Note that you can change the runtime to `win-x64` or any of [those RIDs](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog).